### PR TITLE
:bug: Fix: 벽 삭제 로직 오류 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,16 +651,11 @@
             벽 삭제
             '''
             wall.parentNode.removeChild(wall)
-            
-            if(wall.dataset.direction=='portrait'):
-                x, y = _get_position(wall.style.top, wall.style.left, 'portrait')
-                type = wall.dataset.type
-                wall_data[type].remove((x, y))
-            else:  
-                x, y = _get_position(wall.style.top, wall.style.left, 'landscape')
-                type = wall.dataset.type
-                wall_data[type].remove((x, y))
-
+        
+            x, y = _get_position(wall.style.top, wall.style.left)
+            type = wall.dataset.type
+            wall_data[type].remove((x, y))
+        
 
         @when("mousemove", selector=".wall-container")
         def mouse_on(evt):
@@ -709,17 +704,13 @@
             return integer
 
         # wall css 위치값(top, left)로 좌표값 반환
-        def _get_position(top,left, type):
+        def _get_position(top,left):
             # px 텍스트 값을 실수로 변경
-            top = float(top[:-2])
-            left = float(left[:-2])
+            top = int(top[:-2])
+            left = int(left[:-2])
             
             box_size = map_size+border_size*2
-            if (type=='portrait'):
-                return top/box_size - 0.5, left/box_size-0.5
-            else: # landscape
-                return top/box_size, (left+border_size)/box_size-0.5
-
+            return top/box_size - 0.5, (left-1)/box_size-0.5
 
         # radio 속성을 선택했을 때, wall_type을 변경하는 이벤트 등록
         @when("change", selector="input[name='wall-type']")


### PR DESCRIPTION
# Summarize
벽 삭제 로직 오류 수정

# Description
벽 추가 시, (x, y) 값을 이용하여 스타일을 계산합니다. 방향에 관계없이 적용되도록 해당 변환식을 변경하는 과정에서 로직의 충돌이 있었습니다.
벽 삭제 시, 스타일 값을 통해 (x, y) 값을 구하고, wall_data에서 해당 좌표를 삭제하기 위하여 변환식을 수정했습니다. 
```py
# index.html
def _get_position(top,left):
        # px 텍스트 값을 실수로 변경
    ...
    box_size = map_size+border_size*2
    return top/box_size - 0.5, (left-1)/box_size-0.5
```

# checklist
- [x] 캐릭터의 앞에 벽을 추가, 삭제 후 front_is_clear() 메서드 실행 시 '비어있음' 출력
- [x] 벽 삭제 시, 화면에 벽이 사라짐