### PR TITLE
📝 PR: 스토리 모드 맵 정보 로드 이슈 처리

### DIFF
--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -125,7 +125,14 @@ storyList.addEventListener('click', (e) => {
         (e.target.tagName =
             'BUTTON' && e.target.classList.contains('btn-toggle'))
     ) {
-        e.target.closest('li').classList.toggle('active');
+        const liElem = e.target.closest('li');
+        liElem.classList.toggle('active');
+
+        storyList.querySelectorAll('li').forEach((li) => {
+            if (li !== liElem) {
+                li.classList.remove('active');
+            }
+        });
     }
 });
 

--- a/assets/py/coordinate.py
+++ b/assets/py/coordinate.py
@@ -97,8 +97,8 @@ story_wall = {
         },
     # 4번 스토리
     4:{
-        "map_width":4, 
-        "map_height":4, 
+        "map_width":5, 
+        "map_height":5, 
         "wall":{ # (x, y): 'wall', 'fence', 'door'
             (0, 0.5): '', (0, 1.5): '', (0, 2.5): '', (0, 3.5): '',
             (0.5, 0): 'wall', (0.5, 1): 'wall', (0.5, 2): 'wall', (0.5, 3): 'wall', (0.5, 4): 'wall', 

--- a/assets/py/coordinate.py
+++ b/assets/py/coordinate.py
@@ -97,8 +97,8 @@ story_wall = {
         },
     # 4번 스토리
     4:{
-        "map_width":5, 
-        "map_height":5, 
+        "map_width":4, 
+        "map_height":4, 
         "wall":{ # (x, y): 'wall', 'fence', 'door'
             (0, 0.5): '', (0, 1.5): '', (0, 2.5): '', (0, 3.5): '',
             (0.5, 0): 'wall', (0.5, 1): 'wall', (0.5, 2): 'wall', (0.5, 3): 'wall', (0.5, 4): 'wall', 

--- a/assets/py/item.py
+++ b/assets/py/item.py
@@ -25,6 +25,7 @@ class Item:
         """
         해당 좌표에 아이템이 있는지 확인하는 함수
         """
+        
         # self.target에 자식요소가 있으면 true, 없으면 false
         if self.target.hasChildNodes():
             item = self.target.querySelector(".item")
@@ -32,12 +33,19 @@ class Item:
             return {"name": list(item.classList)[1], "count": count}
         else:
             return False
+        
+    def can_draw(self):
+        """
+        아이템이 추가될 x, y 좌표가 유효한지 판단하는 함수
+        """
+        if not (0<= self.x < map_data['height'] and 0<= self.y < map_data['width']):
+            return False
+        return True
 
     def draw(self):
         """
         x좌표, y좌표에 item을 생성하는 함수
         """
-
         target_item = self.item_exist()
         if target_item:
             if target_item["name"] == self.name:

--- a/assets/py/item.py
+++ b/assets/py/item.py
@@ -34,14 +34,6 @@ class Item:
         else:
             return False
         
-    def can_draw(self):
-        """
-        아이템이 추가될 x, y 좌표가 유효한지 판단하는 함수
-        """
-        if not (0<= self.x < map_data['height'] and 0<= self.y < map_data['width']):
-            return False
-        return True
-
     def draw(self):
         """
         x좌표, y좌표에 item을 생성하는 함수

--- a/index.html
+++ b/index.html
@@ -513,15 +513,20 @@
         @when("click", selector="#init")
         def init(evt=None):
             global wall_data
+            global wall_container
             js.console.log('월드 초기화')
             map_data['height'] = 5
             map_data['width'] = 5
+
+            idx = story_select['index']
+
             map_slider_x.value = 5
             map_slider_y.value = 5
             item_data.clear()
             map_slider_output_x.innerHTML = map_slider_x.value
             map_slider_output_y.innerHTML = map_slider_y.value
             map_exist = js.document.querySelector('.map-container')
+
             # TODO: map object는 map_data에서 관리해야할 것으로 보임
             if map_exist:
                 js.document.querySelector('.map-container').remove()
@@ -530,22 +535,17 @@
                 draw_map.appendChild(draw_character)
                 app = Element("app").element
                 app.appendChild(draw_map)
-
                 
                 wall.resetWall(map_data['width'], map_data['height'])
-                
-                if(story_select['status']):
-                    idx = story_select['index']
-                    if(story_wall.get(idx)):
-                        map_data['height']= story_wall[idx]['map_height']
-                        wall_data['world']= story_wall[idx]['wall']
-                        wall.wall_data = story_wall[idx]['wall']
+                if(story_select['status'] and story_wall.get(idx)):
+                    wall_data['world']= story_wall[idx]['wall']
+                    wall.wall_data = story_wall[idx]['wall']
 
-                        items = story_wall[idx]['item']
+                    items = story_wall[idx]['item']
 
-                        for pos in items:
-                            item = Item(pos[0], pos[1], items[pos]['item'], items[pos]['count'])
-                            item.draw()
+                    for pos in items:
+                        item = Item(pos[0], pos[1], items[pos]['item'], items[pos]['count'])
+                        item.draw()
 
                 wall_container = wall.drawWall()
                 wall_data['world']= wall.wall_data
@@ -846,25 +846,25 @@
             js.document.getElementById('notebookSection').appendChild(newRepl)
         
         storyList = js.document.querySelectorAll('.story-list>li')
-        @when("click", selector=".story-list>li")
-        def set_story_map(evt=None):
-            if(evt.target.tagName=='BUTTON'):
-                if (evt.currentTarget.classList.contains('active')):
-                    story_select['index']=0
-                else:
-                    story_select['index']=list(storyList).index(evt.currentTarget)+1
-                init()                
+        @when("click", selector=".story-title .btn-toggle")
+        def select_story(evt=None):
+            liElem = evt.target.closest('li')
+            if not liElem.classList.contains('active'):
+                story_select['index']=list(storyList).index(evt.target.closest('li'))+1 
+            else:
+                story_select['index']=0
+            init()
         
         @when("click", selector=".btn-story")
-        def check_story_open(evt=None):
+        def change_storymode(evt=None):
             if(evt.target.classList.contains('active')):
                 story_select['status'] = True
                 if not (js.document.querySelector('.story-list>li.active')):
                     story_select['index'] = 0
             else:
                 story_select['status'] = False
-            init()                
-
+            init()    
+        
         
         @when('click', selector='.btn-close-story')
         def story_close(evt=None):

--- a/index.html
+++ b/index.html
@@ -520,6 +520,11 @@
 
             idx = story_select['index']
 
+            if(story_select['status'] and story_wall.get(idx)):
+
+                map_data['width']= story_wall[idx]['map_width']
+                map_data['height']= story_wall[idx]['map_height']
+                
             map_slider_x.value = 5
             map_slider_y.value = 5
             item_data.clear()

--- a/index.html
+++ b/index.html
@@ -551,7 +551,10 @@
 
                     for pos in items:
                         item = Item(pos[0], pos[1], items[pos]['item'], items[pos]['count'])
-                        item.draw()
+                        if item.can_draw():
+                            item.draw()
+                        else:
+                            del item_data[(pos[0], pos[1])]
 
                 wall_container = wall.drawWall()
                 wall_data['world']= wall.wall_data

--- a/index.html
+++ b/index.html
@@ -545,17 +545,16 @@
                 if(story_select['status'] and story_wall.get(idx)):
                     wall_data['world']= story_wall[idx]['wall']
                     wall.wall_data = story_wall[idx]['wall']
+                
                     wall.resizeWall(story_wall[idx]['map_width'],story_wall[idx]['map_height'])
 
                     items = story_wall[idx]['item']
 
                     for pos in items:
-                        item = Item(pos[0], pos[1], items[pos]['item'], items[pos]['count'])
-                        if item.can_draw():
+                        if ( 0 <= pos[0] < map_data['height'] and 0 <= pos[1] < map_data['width']):
+                            item = Item(pos[0], pos[1], items[pos]['item'], items[pos]['count'])
                             item.draw()
-                        else:
-                            del item_data[(pos[0], pos[1])]
-
+                        
                 wall_container = wall.drawWall()
                 wall_data['world']= wall.wall_data
 

--- a/index.html
+++ b/index.html
@@ -545,6 +545,7 @@
                 if(story_select['status'] and story_wall.get(idx)):
                     wall_data['world']= story_wall[idx]['wall']
                     wall.wall_data = story_wall[idx]['wall']
+                    wall.resizeWall(story_wall[idx]['map_width'],story_wall[idx]['map_height'])
 
                     items = story_wall[idx]['item']
 


### PR DESCRIPTION
# Summarize
- 스토리 선택 시, 문항 로드 오류 수정
- 스토리의 map_width, map_height 크기 적용

# Description
## 스토리 보기
<img width="55" alt="스크린샷 2023-10-06 오전 11 02 16" src="https://github.com/weniv/weniv_world/assets/96777064/61c2778d-2474-4bb9-9c82-4f2a1dbb0547">  

- 스토리 모드로 설정. 맵 편집 불가
- 열려있는 스토리가 있으면 해당 스토리로 월드 세팅

## 스토리 열기
<img width="484" alt="스크린샷 2023-10-06 오전 11 03 07" src="https://github.com/weniv/weniv_world/assets/96777064/6de92c5b-8eac-4579-9f89-82e02cbe911c">  

- 한 개의 스토리만 열려있음. 항목 선택 시, 열려있는 다른 스토리 접기
- 스토리가 열렸을 때, 선택된 스토리의 문항 번호를 받아 맵 설정
- init() 메서드를 다음과 같이 수정하여, map 크기 및 맵을 벗어나는 요소 제거
  - 맵 크기 설정
  ```py
  # 맵 크기 설정
  idx = story_select['index']
  if(story_select['status'] and story_wall.get(idx)):
    map_data['width']= story_wall[idx]['map_width']
    map_data['height']= story_wall[idx]['map_height']
  ```
  - 맵을 벗어나는 벽 제거. coordinate 수정X, wall_data['world'] 수정O
  ```py
  if(story_select['status'] and story_wall.get(idx)):
    wall_data['world']= story_wall[idx]['wall']
    wall.wall_data = story_wall[idx]['wall']
    wall.resizeWall(story_wall[idx]['map_width'],story_wall[idx]['map_height'])
  ```
  - 아이템: 맵을 넘어가는 아이템은 추가X
  ```py
    if ( 0 <= pos[0] < map_data['height'] and 0 <= pos[1] < map_data['width']):
    item = Item(pos[0], pos[1], items[pos]['item'], items[pos]['count'])
    item.draw()
  ```
  

# Issue
- #112 테스트 동안 해당 이슈가 발생하지 않아 클로즈하겠습니다.
- 추후 해당 이슈가 발생하면 다시 오픈하여 작업하겠습니다.
close #110 , #112 

# CheckList
- [x] 스토리를 선택했을 때, 맵이 잘 설정되는가
- [x] coordinate 맵 크기가 적용되는가
- [x] 맵을 벗어나는 벽은 없는가
- [x] 맵을 벗어나는 아이템은 추가되지 않는가
- [x] 스토리 선택 시, 다른 스토리는 active가 해제되는가