### PR TITLE
📝 PR: open 메서드 순차 실행, pick 오류 해결

### DIFF
--- a/assets/py/built_in_functions.py
+++ b/assets/py/built_in_functions.py
@@ -98,8 +98,6 @@ def set_item(x, y, name, count=1, description={}, character=None):
 
     item = Item(x, y, name, count, description)
     item.draw()
-    if character_data[0]["character_obj"] != None:
-        character_data[0]["character_obj"].pick()
 
 
 def move(character=None):

--- a/assets/py/built_in_functions.py
+++ b/assets/py/built_in_functions.py
@@ -154,10 +154,10 @@ def repeat(count, f):
 def front_is_clear(character=None):
     if character != None:
         print(f"character not none")
-        character.front_is_clear()
+        return character.front_is_clear()
     else:
         if character_data[0]["character_obj"] != None:
-            character_data[0]["character_obj"].front_is_clear()
+            return character_data[0]["character_obj"].front_is_clear()
         else:
             print("캐릭터가 없습니다.")
 

--- a/assets/py/character.py
+++ b/assets/py/character.py
@@ -435,13 +435,10 @@ class Character:
             posX, posY = (self.x + 0.5, self.y)
 
         if not (0 <= posX < map_data["height"] and 0 <= posY < map_data["width"]):
-            print("맵을 벗어납니다.")
             return False
 
         if wall_data["world"][(posX, posY)]:
-            print(f"{self.name}의 {target}은 비어있지 않습니다.")
             return False
-        print(f"{self.name}의 {target}은 비어있습니다.")
         return True
 
     def directions(self):

--- a/assets/py/character.py
+++ b/assets/py/character.py
@@ -448,6 +448,11 @@ class Character:
         self.running_time = 0
 
     def open(self):
+        self.running_time += 1000 * running_speed
+        setTimeout(create_once_callable(lambda: (self._open())), self.running_time)
+        setTimeout(create_once_callable(lambda: self.init_time()), self.running_time)
+        
+    def _open(self):
         if (self.typeof_wall()=='door'):
             self._set_wall(self._front_wall(), '')
         elif (self.typeof_wall()==''):

--- a/assets/py/character.py
+++ b/assets/py/character.py
@@ -259,20 +259,27 @@ class Character:
         x = character_data[0]["x"]
         y = character_data[0]["y"]
         item = item_data.get((x, y))
+        
         if item:
             item_count = item.get("count", 0)
             item_count -= 1
             item["count"] = item_count
             item_data[(x, y)] = item
+            
             # TODO: 0번째에서 꺼내는 것이 아니라 자신의 아이템에서 꺼내야 함.
             if item["item"] in character_data[0]["items"].keys():
                 character_data[0]["items"][item["item"]] += 1
             else:
                 character_data[0]["items"][item["item"]] = 1
+                
             if item_count == 0:
-                js.document.querySelector(f".count{x}{y}").remove()
-                js.document.querySelector(f".item{x}{y}").remove()
+                map_items = js.document.querySelectorAll(".map-item")
+                index = map_data["width"] * x + y
+                target = map_items[index]
+                target.removeChild(target.querySelector(".item-container"))
                 item_data.pop((x, y))
+            else:
+                js.document.querySelector(f".count{x}{y}").innerHTML = item_count
             return item_count
         else:
             return "발 아래 아이템이 없습니다!"


### PR DESCRIPTION
# Summarize
- 코드 순서에 따라 open() 메서드 실행
- Pick() : #57 해결 , 아이템 삭제 로직 수정

# Description
## 코드 순서에 따라 처리
- 코드 블럭 실행 시, 코드가 바로 실행되는 것이 아닌 순차적으로 실행되어야 함.
  - ex) move->turn_left->move 순서대로 실행되어야함. 동시 실행X
- `create_once_callable` 메서드를 이용하여 순차 처리
```py
def open(self):
        self.running_time += 1000 * running_speed
        setTimeout(create_once_callable(lambda: (self._open())), self.running_time)
        setTimeout(create_once_callable(lambda: self.init_time()), self.running_time)
```
- 🚨 반환값이 있는 directions(), typeof_wall(), _is_clear() 함수를 `create_once_callable`에서 처리하고 값을 반환하는 로직 필요
  - #114 

## pick
- 기존 pick() 메서드도 create_once_callable 처리가 되지 않아서  set_item과 같은 코드 블럭에 있으면 실행되지 않았습니다.
- pick이 create_once_callable 처리가 됨에 따라 아래 코드를 삭제합니다.
- 따라서, 캐릭터의 위치에서 set_item 메서드를 실행해도 pick 처리 되지않습니다.
```py
# set_item()

if character_data[0]["character_obj"] != None:
        character_data[0]["character_obj"].pick()
```
- close #57 

# Checklist
- [x] open() 함수가 순차적으로 처리된다.
- [x] 캐릭터의 위치에 set_item을 실행 후, pick() 메서드가 자동 실행되지 않는다.
- [x] set_item과 pick 메서드가 같은 코드 블럭에서 실행될 때, pick() 메서드가 실행된다.