### PR TITLE
📝 PR: 스토리 토글 버튼 이벤트 통합 및 객체 연결

### DIFF
--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -120,22 +120,6 @@ storyCloseButton.addEventListener('click', () => {
     storyResizer.style.display = 'none';
 });
 
-storyList.addEventListener('click', (e) => {
-    if (
-        (e.target.tagName =
-            'BUTTON' && e.target.classList.contains('btn-toggle'))
-    ) {
-        const liElem = e.target.closest('li');
-        liElem.classList.toggle('active');
-
-        storyList.querySelectorAll('li').forEach((li) => {
-            if (li !== liElem) {
-                li.classList.remove('active');
-            }
-        });
-    }
-});
-
 // 툴팁 표시
 const tooltipTargetElement = document.querySelectorAll('.show-tooltip');
 

--- a/index.html
+++ b/index.html
@@ -886,9 +886,7 @@
                     story_select['index']=list(storyItems).index(evt.target.closest('li'))+1 
                 else:
                     story_select['index']=0
-
-                
-            init()
+                init()
         
         @when("click", selector=".btn-story")
         def change_storymode(evt=None):

--- a/index.html
+++ b/index.html
@@ -482,7 +482,10 @@
                     add_event_listener(wall_elem,'mouseenter',wall_mouse_enter)
                     add_event_listener(wall_elem,'mouseleave',wall_mouse_leave)
 
-                draw_map.appendChild(wall_container)
+                
+                # story_list에 이벤트 추가하기
+                storyElem = js.document.querySelector('.story-list')
+                add_event_listener(storyElem,'click',set_story)
 
             # 범위를 벗어난 아이템 삭제
             global item_data
@@ -868,14 +871,22 @@
             newRepl.textContent = ''
             js.document.getElementById('notebookSection').appendChild(newRepl)
         
-        storyList = js.document.querySelectorAll('.story-list>li')
-        @when("click", selector=".story-title .btn-toggle")
-        def select_story(evt=None):
-            liElem = evt.target.closest('li')
-            if not liElem.classList.contains('active'):
-                story_select['index']=list(storyList).index(evt.target.closest('li'))+1 
-            else:
-                story_select['index']=0
+        @when("click", selector = ".story-list")
+        def set_story(evt=None):
+            if(evt.target.tagName == 'BUTTON' and evt.target.classList.contains('btn-toggle')):
+                storyItems = js.document.querySelectorAll('.story-list>li')
+                liElem = evt.target.closest('li')
+                liElem.classList.toggle('active')
+
+                if(liElem.classList.contains('active')):
+                    story_select['index']=list(storyItems).index(evt.target.closest('li'))+1 
+                else:
+                    story_select['index']=0
+
+                for li in storyItems:
+                    if(li != evt.target.closest('li')):
+                        li.classList.remove('active')
+                
             init()
         
         @when("click", selector=".btn-story")

--- a/index.html
+++ b/index.html
@@ -878,14 +878,15 @@
                 liElem = evt.target.closest('li')
                 liElem.classList.toggle('active')
 
+                for li in storyItems:
+                    if(li != evt.target.closest('li')):
+                        li.classList.remove('active')
+
                 if(liElem.classList.contains('active')):
                     story_select['index']=list(storyItems).index(evt.target.closest('li'))+1 
                 else:
                     story_select['index']=0
 
-                for li in storyItems:
-                    if(li != evt.target.closest('li')):
-                        li.classList.remove('active')
                 
             init()
         


### PR DESCRIPTION
# Summarize
- 스토리 토글 버튼 이벤트 1개로 통합 
- 화면 초기화 후, 객체에 이벤트 함수 연결

# Description
## 스토리 토글 버튼 이벤트
- event.js, index.html 각각 이벤트가 등록되어 있고, 핸들러 적용 순서에 따라서 오류가 발생할 수 있어 함수 통일
- python 객체 사용을 위해 index.html 에 이벤트를 통합하여 작성
- 버튼이 눌렸을 때만 동작하도록 evt.target 을 사용
```py
@when("click", selector = ".story-list")
def set_story(evt=None):
    # 기존 event.js에 등록되어 있던 이벤트 함수
    if(evt.target.tagName == 'BUTTON' and evt.target.classList.contains('btn-toggle')):
        storyItems = js.document.querySelectorAll('.story-list>li')
        liElem = evt.target.closest('li')
        liElem.classList.toggle('active')
        
        for li in storyItems:
            if(li != evt.target.closest('li')):
                li.classList.remove('active')
    
    # active가 된 경우에, index를 갱신
        if(liElem.classList.contains('active')):
            story_select['index']=list(storyItems).index(evt.target.closest('li'))+1 
        else:
            story_select['index']=0
        init()
```

## 이벤트 위임
- story의 정보를 동적으로 불러오기 때문에, 이벤트 위임으로 ul.story-list에 이벤트를 등록
- story-list의 자식 요소가 불러오기 전에 이벤트가 등록되어도, 이벤트 적용이 가능

## 객체에 이벤트 함수 등록
- init() 함수 실행 시, 객체에 이벤트 함수를 연결합니다.
```py

  # story_list에 이벤트 추가하기
  storyElem = js.document.querySelector('.story-list')
  add_event_listener(storyElem,'click',set_story)

```

# Checklist
- [ ] 스토리 선택 시, 해당 맵이 설정되는가  (로컬 / 배포)