### PR TITLE
📝 PR: 객체 이벤트 연결 삭제

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,10 +482,6 @@
                     add_event_listener(wall_elem,'mouseenter',wall_mouse_enter)
                     add_event_listener(wall_elem,'mouseleave',wall_mouse_leave)
 
-                
-                # story_list에 이벤트 추가하기
-                storyElem = js.document.querySelector('.story-list')
-                add_event_listener(storyElem,'click',set_story)
 
             # 범위를 벗어난 아이템 삭제
             global item_data


### PR DESCRIPTION
# Summarize
- 객체 이벤트 연결 삭제

# Description
## 객체 이벤트 연결 삭제
- PyScript에서 객체를 삭제하는 경우 이벤트가 사라져, add_event_listner로 이벤트 연결 필요
- story-list 객체를 삭제하는 코드가 없어, 다음 코드가 불필요해 삭제합니다.
```py
# story_list에 이벤트 추가하기
storyElem = js.document.querySelector('.story-list')
add_event_listener(storyElem,'click',set_story)
```
