### PR TITLE
📝 PR: 라이캣 이미지 프리로딩

### DIFF
--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -342,3 +342,18 @@ window.addEventListener('click', (e) => {
             kebabMenu.classList.remove('active');
     }
 });
+
+// 이미지 프리로드
+const preloadImage = (imgList) => {
+    imgList.forEach((src) => {
+        const img = new Image();
+        img.src = src;
+    });
+};
+// 라이캣 이미지 프리로드
+preloadImage([
+    './assets/img/characters/licat-0.png',
+    './assets/img/characters/licat-1.png',
+    './assets/img/characters/licat-2.png',
+    './assets/img/characters/licat-3.png',
+]);


### PR DESCRIPTION
# Summarize
- 이미지 깜빡임 현상 해결을 위해 이미지 프리로딩
- close #154 

# Description
- 초기 로딩 시에만 이미지 깜빡임 현상 발생 -> 이미지를 로드하는 과정에서 생기는 현상
- 초기 로딩 시에, 이미지를 캐시에 저장하여 해당 현상을 해결

# Checklist
- [ ] 강력 새로고침 후, turn_left()를 실행시켰을 때 이미지 깜빡임이 발생하지 않는가?
\* 로컬에서 확인이 되지 않아 머지 후 배포 페이지에서 확인하겠습니다