### PR TITLE
📝 PR: 클릭으로 아이템 추가할 때 개수 추가

### DIFF
--- a/assets/py/event.py
+++ b/assets/py/event.py
@@ -584,7 +584,7 @@ def map_item_add(evt):
 
         item_select["status"] = False
         item_select["name"] = ""
-        js.document.querySelector(".map-container").style.cursor = "auto"
+        js.document.querySelector(".map-container").style.cursor = "default"
         js.document.querySelector(".wall-container").style.pointerEvents = ""
 
 

--- a/index.html
+++ b/index.html
@@ -1000,7 +1000,7 @@
                 evt.target.style.backgroundColor = ''
 
                 count = 0
-                input_count = js.prompt('아이템 개수를 입력하세요', '1')
+                input_count = js.prompt('추가할 아이템 개수를 입력하세요\n(* 추가할 위치에 다른 아이템이 있는 경우 사라집니다.)', '1')
 
                 # 양의 정수이면 count에 저장 / 입력값이 없으면 None 반환 / 입력값이 유효하지 않으면 alert
                 if not input_count:
@@ -1010,7 +1010,9 @@
                     return None
                 else:
                     count = int(input_count)
-                    if item_data.get((x,y))==item_select['name']:
+                    on_item = item_data.get((x,y))
+                    
+                    if item_data.get((x,y),{}).get('item','')==item_select['name']:
                         item_data[(x,y)]['count'] += count
                     else:
                         item_data[(x,y)] = {

--- a/index.html
+++ b/index.html
@@ -999,7 +999,18 @@
                 x, y = divmod(index, map_data['width'])
                 evt.target.style.backgroundColor = ''
 
-                count = 1
+                count = 0
+                input_count = js.prompt('아이템 개수를 입력하세요', '1')
+
+                # 양의 정수이면 count에 저장 / 입력값이 없으면 None 반환 / 입력값이 유효하지 않으면 alert
+                if not input_count:
+                    return None
+                elif not input_count.isdigit() or int(input_count)<0:
+                    js.alert('자연수를 입력해주세요.')
+                    return None
+                else:
+                    count = int(input_count)
+
                 if item_data.get((x,y))==item_select['name']:
                     item_data[(x,y)]['count'] += count
                 else:
@@ -1008,15 +1019,11 @@
                         'count': count
                     }
 
-              
-
                 item_select['status']=False
                 item_select['name']=''
-                js.document.querySelector('.map-container').style.cursor='auto'
                 js.document.querySelector('.wall-container').style.pointerEvents=''
+                js.document.querySelector('.map-container').style.cursor='auto'
             change_map()
-
-
 
         @when("click", selector="#output-init")
         def init_output(evt=None):

--- a/index.html
+++ b/index.html
@@ -1004,20 +1004,19 @@
 
                 # 양의 정수이면 count에 저장 / 입력값이 없으면 None 반환 / 입력값이 유효하지 않으면 alert
                 if not input_count:
-                    return None
+                    pass
                 elif not input_count.isdigit() or int(input_count)<0:
                     js.alert('자연수를 입력해주세요.')
                     return None
                 else:
                     count = int(input_count)
-
-                if item_data.get((x,y))==item_select['name']:
-                    item_data[(x,y)]['count'] += count
-                else:
-                    item_data[(x,y)] = {
-                        'item': item_select['name'],
-                        'count': count
-                    }
+                    if item_data.get((x,y))==item_select['name']:
+                        item_data[(x,y)]['count'] += count
+                    else:
+                        item_data[(x,y)] = {
+                            'item': item_select['name'],
+                            'count': count
+                        }
 
                 item_select['status']=False
                 item_select['name']=''


### PR DESCRIPTION
# Summarize
- 클릭으로 아이템 추가 시 개수 입력 #160 

# Description
- 아이템을 선택 후 추가할 위치에 클릭하면 아이템의 개수를 입력할 수 있는 prompt 창이 출력
- 양의 정수(자연수)가 입력되면 해당 개수만큼 아이템이 추가
    - 추가한 위치에 동일한 아이템이 있으면 개수 추가 / 다른 아이템이 있으면 덮어쓰기
 - 입력값이 있으나 유효하지 않은 경우, 경고 메시지 출력 후 다시 클릭할 수 있습니다.
 - 입력값이 없는 경우(ESC, 취소), 추가 이벤트가 종료됩니다.

# Checklist
- [x] 빈 칸에 아이템을 추가했을 때, 입력한 수만큼 올바르게 추가되는가? 
- [x] 같은 아이템이 있는 경우, 입력값 만큼 개수가 추가되는가?
- [x] 다른 아이템이 있는 경우, 덮어쓰기 되는가?
- [x] 유효하지 않는 값(자연수가 아닌 값)을 입력했을 때 안내 메시지가 출력되고, 다시 추가할 수 있는가?
- [x] item_data에 올바르게 반영되는가?

close #160 