### PR TITLE
🚑 Fix: 아이템 추가 예외처리

### DIFF
--- a/assets/py/built_in_functions.py
+++ b/assets/py/built_in_functions.py
@@ -3,7 +3,7 @@ import js
 from pyodide.ffi import create_once_callable
 from coordinate import character_data, map_data,running_speed, mob_data
 from item import Item
-from coordinate import item_data
+from coordinate import item_data, _available_items
 
 
 command_count = 1 # 명령어 줄 수
@@ -127,6 +127,11 @@ def set_item(x, y, name, count=1, description={}, character=None):
     if not (0 <= x < map_data["height"] and 0 <= y < map_data["width"]):
         js.alert("월드를 벗어나서 아이템을 추가할 수 없습니다.")
         print("error.OutOfWorld: out of world", type="error")
+        return None
+    
+    if name not in _available_items:
+        js.alert("존재하지 않는 아이템입니다.")
+        print("error.ItemIsNotExist: item is not exist", type="error")
         return None
 
     item = Item(x, y, name, count, description)

--- a/assets/py/coordinate.py
+++ b/assets/py/coordinate.py
@@ -16,6 +16,9 @@ mob_data = []
 # (x, y): {item: 'beeper', count: 1}
 item_data = {}
 
+# 이용 가능한 아이템 종류
+_available_items = ['fish-1','fish-2','fish-3','diamond','apple','goldbar']
+
 # 맵 크기
 map_data = {"height": 5, "width": 5}
 


### PR DESCRIPTION
# Summarize
- 존재하지 않는 이름의 아이템 추가 예외처리

# Description
- `coordinate.py`에 이용가능한 아이템(`_available_items`) 리스트 선언
- 사용자가 입력한 아이템 이름이 리스트에 있는지 판별하여 오류 메시지 출력

# Checklist
- [x] set_item으로 아이템 추가 시, 이름이 잘못되었을 때 오류 메시지가 출력되는가?